### PR TITLE
Allow to deploy master branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ services:
 
 script:
   - docker-compose build
+  - source devel.env
+  - docker-compose build
 
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -22,4 +22,14 @@ And it will start all those containers in the right order. Once started, you
 can point your browser at `http://<ip of docker>:3000` to access Grafana. The
 default username is "admin" and password is "password".
 
+Devel
+=====
+
+To run master branches of Gnocchi, collectd-gnocchi, grafana-gnocchi-datasource, run::
+
+  $ source devel.en
+  $ docker-compose build --no-cache --force-rm  # To force rebuild image from source
+  $ docker-compose up
+
+
 .. _Gnocchi: http://gnocchi.xyz

--- a/collectd/Dockerfile
+++ b/collectd/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:xenial
+ARG package_name=collectd-gnocchi
 
 RUN apt-get update -y && apt-get install -y \
     collectd \
@@ -12,7 +13,7 @@ RUN apt-get update -y && apt-get install -y \
     stress \
  && rm -rf /var/lib/apt/lists/*
 
-RUN pip install envtpl collectd-gnocchi
+RUN pip install envtpl ${package_name}
 COPY collectd.conf.tpl /etc/collectd
 COPY run.sh /
 CMD /run.sh

--- a/collectd/run.sh
+++ b/collectd/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 exec >&2
 
+# NOTE(sileht): To get collectd-gnocchi version in log
+pip freeze | grep collectd-gnocchi
+
 export COLLECTD_HOST=fake-phy-host-$(hostname -f)
 export OS_AUTH_TYPE=gnocchi-basic
 export GNOCCHI_USER=admin

--- a/devel.env
+++ b/devel.env
@@ -1,0 +1,3 @@
+export GNOCCHI_PACKAGE_NAME=git+https://github.com/gnocchixyz/gnocchi@master#egg=gnocchi
+export COLLECTD_GNOCCHI_PACKAGE_NAME=git+https://github.com/gnocchixyz/collectd-gnocchi@master#egg=collectd-gnocchi
+export GRAFANA_PLUGIN_URL=https://github.com/gnocchixyz/grafana-gnocchi-datasource/archive/master.tar.gz

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       POSTGRESQL_USER: postgres
     build:
       context: gnocchi
+      args:
+        package_name: "${GNOCCHI_PACKAGE_NAME:-gnocchi}"
     depends_on:
       - indexer
       - storage
@@ -26,6 +28,8 @@ services:
       POSTGRESQL_USER: postgres
     build:
       context: gnocchi
+      args:
+        package_name: "${GNOCCHI_PACKAGE_NAME:-gnocchi}"
     ports:
       - "8041:8041"
     depends_on:
@@ -41,9 +45,10 @@ services:
     build:
       context: grafana
     environment:
-      # GF_INSTALL_PLUGINS: gnocchixyz-gnocchi-datasource
-      GF_SECURITY_ADMIN_PASSWORD: password
-      GF_GNOCCHI_ENDPOINT: http://gnocchi:8041
+      - GRAFANA_PLUGIN_URL
+      # - GF_INSTALL_PLUGINS=gnocchixyz-gnocchi-datasource
+      - GF_SECURITY_ADMIN_PASSWORD=password
+      - GF_GNOCCHI_ENDPOINT=http://gnocchi:8041
     ports:
       - "3000:3000"
     depends_on:
@@ -57,6 +62,8 @@ services:
     image: collectd
     build:
       context: collectd
+      args:
+        package_name: "${COLLECTD_GNOCCHI_PACKAGE_NAME:-collectd-gnocchi}"
     environment:
       COLLECTD_INTERVAL: 10
     depends_on:

--- a/gnocchi/Dockerfile
+++ b/gnocchi/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.5-slim
+ARG package_name=gnocchi
 
 RUN apt-get update && apt-get install -y \
     build-essential \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 ADD run-gnocchi.sh /
-RUN pip install -U gnocchi[file,redis,postgresql] uwsgi
+RUN pip install -U ${package_name}[file,redis,postgresql] uwsgi
 RUN mkdir /etc/gnocchi
 ADD uwsgi.ini /etc/gnocchi
 EXPOSE 8041

--- a/gnocchi/run-gnocchi.sh
+++ b/gnocchi/run-gnocchi.sh
@@ -3,6 +3,9 @@ printf "[indexer]\nurl = postgresql://${POSTGRESQL_USER}:${POSTGRESQL_PASSWORD}@
 printf "[storage]\ncoordination_url = redis://:${REDIS_PASSWORD}@storage\n" >> /etc/gnocchi/gnocchi.conf
 printf "[incoming]\ndriver = redis\nredis_url = redis://:${REDIS_PASSWORD}@storage\n" >> /etc/gnocchi/gnocchi.conf
 
+# NOTE(sileht): To get Gnocchi version build log
+pip freeze | grep gnocchi
+
 gnocchi-upgrade || true
 
 case $1 in

--- a/grafana/install-plugin.sh
+++ b/grafana/install-plugin.sh
@@ -5,8 +5,18 @@ set -x
 
 : "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
 mkdir -p ${GF_PATHS_PLUGINS}
-cd ${GF_PATHS_PLUGINS}
 
-URL=$(curl https://api.github.com/repos/gnocchixyz/grafana-gnocchi-datasource/releases/latest | awk -F'"' '/browser_download_url/{print $4}')
+if [ "${GRAFANA_PLUGIN_URL}" ]; then
+    URL=${GRAFANA_PLUGIN_URL}
+else
+    URL=$(curl https://api.github.com/repos/gnocchixyz/grafana-gnocchi-datasource/releases/latest | awk -F'"' '/browser_download_url/{print $4}')
+fi
 curl -qL $URL -o  /gnocchixyz-gnocchi-datasource.tar.gz
-tar -xf /gnocchixyz-gnocchi-datasource.tar.gz
+
+mkdir -p ${GF_PATHS_PLUGINS}/gnocchixyz-gnocchi-datasource
+source_tarball="$(tar -tf /gnocchixyz-gnocchi-datasource.tar.gz --show-transformed-names --strip-components=1 | grep '^dist' || true)"
+if [ -z "$source_tarball" ]; then
+    tar -xf /gnocchixyz-gnocchi-datasource.tar.gz --show-transformed-names --strip-components=1 -C ${GF_PATHS_PLUGINS}/gnocchixyz-gnocchi-datasource
+else
+    tar -xf /gnocchixyz-gnocchi-datasource.tar.gz --show-transformed-names --strip-components=2 --wildcards */dist -C ${GF_PATHS_PLUGINS}/gnocchixyz-gnocchi-datasource
+fi


### PR DESCRIPTION
This change allow to run a custom version of Gnocchi, collectd-gnocchi
and the grafana plugin by setting environment variables.

It also put as example for master branches of each projects.