### PR TITLE
Use rate:last for network interfaces

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -307,7 +307,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "aggregator": "mean",
+                                "aggregator": "rate:last",
                                 "granularity": "",
                                 "label": "$metric",
                                 "metric_name": "interface-eth0@if_octets.*",


### PR DESCRIPTION
Network interfaces are now aggregated with rate:last.

So use this aggregation in Grafana.