### PR TITLE
Use pre-built base images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ services:
   - docker
 
 script:
+  - ./build-base-images.sh
   - docker-compose build
   - source devel.env
   - docker-compose build

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Devel
 To run master branches of Gnocchi, collectd-gnocchi, grafana-gnocchi-datasource, run::
 
   $ source devel.en
+  $ ./build-base-images.sh # Build base images (only once)
   $ docker-compose build --no-cache --force-rm  # To force rebuild image from source
   $ docker-compose up
 

--- a/base/Dockerfile-collectd-base
+++ b/base/Dockerfile-collectd-base
@@ -1,0 +1,17 @@
+FROM ubuntu:xenial
+ARG package_name=collectd-gnocchi
+
+RUN apt-get update -y && apt-get install -y \
+    collectd \
+    python \
+    python-dev \
+    python-pip \
+    libyaml-dev \
+    build-essential \
+    curl \
+    git \
+    stress \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN pip install envtpl ${package_name}
+

--- a/base/Dockerfile-gnocchi-base
+++ b/base/Dockerfile-gnocchi-base
@@ -1,0 +1,9 @@
+FROM python:3.5-slim
+ARG package_name=gnocchi
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install -U ${package_name}[file,redis,postgresql] uwsgi
+

--- a/build-base-images.sh
+++ b/build-base-images.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+set -ex
+
+BASE_IMAGES="gnocchi-base collectd-base"
+OLD_PATH=$PWD
+
+finish() {
+    cd $OLD_PATH
+}
+
+trap finish EXIT
+
+cd base
+for IMG in $BASE_IMAGES; do
+	docker build --no-cache -f Dockerfile-$IMG -t $IMG .
+done
+

--- a/collectd/Dockerfile
+++ b/collectd/Dockerfile
@@ -1,17 +1,5 @@
-FROM ubuntu:xenial
+FROM collectd-base
 ARG package_name=collectd-gnocchi
-
-RUN apt-get update -y && apt-get install -y \
-    collectd \
-    python \
-    python-dev \
-    python-pip \
-    libyaml-dev \
-    build-essential \
-    curl \
-    git \
-    stress \
- && rm -rf /var/lib/apt/lists/*
 
 RUN pip install envtpl ${package_name}
 COPY collectd.conf.tpl /etc/collectd

--- a/gnocchi/Dockerfile
+++ b/gnocchi/Dockerfile
@@ -1,10 +1,5 @@
-FROM python:3.5-slim
+FROM gnocchi-base
 ARG package_name=gnocchi
-
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
-    && rm -rf /var/lib/apt/lists/*
 
 ADD run-gnocchi.sh /
 RUN pip install -U ${package_name}[file,redis,postgresql] uwsgi


### PR DESCRIPTION
It significantly speed up generating gnocchi and collectd images.
Pypi dependencies are pre-installed in base images to reduce the
number of dependencies retrieved during derived images builds.

This is a POC, but after base images are built, it takes less than 30s to rebuild from scratch derived images.
```bash
docker-compose build --no-cache --force-rm  1.24s user 0.10s system 4% cpu 26.949 total
```