### PR TITLE
collectd: stop generate load

### DIFF
--- a/base/Dockerfile-collectd-base
+++ b/base/Dockerfile-collectd-base
@@ -10,7 +10,6 @@ RUN apt-get update -y && apt-get install -y \
     build-essential \
     curl \
     git \
-    stress \
  && rm -rf /var/lib/apt/lists/*
 
 RUN pip install envtpl ${package_name}

--- a/collectd/run.sh
+++ b/collectd/run.sh
@@ -24,10 +24,4 @@ echo "collectd host: $COLLECTD_HOST"
 envtpl --keep-template /etc/collectd/collectd.conf.tpl
 
 echo "starting collectd"
-collectd -f &
-
-echo "starting stress"
-while true ; do
-    stress -c 1 -m 2 -i 1 -t 5 --vm-hang 2
-    sleep 5
-done
+collectd -f


### PR DESCRIPTION
Now, the default dashboard have network/disk/...

No need to generate cpu load to have graph.