### PR TITLE
make some compose services optional

### DIFF
--- a/docker-compose-host.yaml
+++ b/docker-compose-host.yaml
@@ -1,0 +1,16 @@
+---
+version: "3"
+
+services:
+  fake-phy-host:
+    image: collectd
+    build:
+      context: collectd
+      args:
+        package_name: "${COLLECTD_GNOCCHI_PACKAGE_NAME:-collectd-gnocchi}"
+    environment:
+      COLLECTD_INTERVAL: 10
+    depends_on:
+      - gnocchi-api
+    links:
+      - "gnocchi-api:gnocchi"

--- a/docker-compose-prom.yaml
+++ b/docker-compose-prom.yaml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  prom:
+    image: prometheus
+    build:
+      context: prometheus
+    depends_on:
+      - gnocchi-api
+    ports:
+      - "9090:9090"
+    links:
+      - "gnocchi-api:gnocchi"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,4 @@
+---
 version: "3"
 
 services:
@@ -47,7 +48,6 @@ services:
     environment:
       - GNOCCHI_RATE_SUPPORT
       - GRAFANA_PLUGIN_URL
-      # - GF_INSTALL_PLUGINS=gnocchixyz-gnocchi-datasource
       - GF_SECURITY_ADMIN_PASSWORD=password
       - GF_GNOCCHI_ENDPOINT=http://gnocchi:8041
     ports:
@@ -56,30 +56,6 @@ services:
       - gnocchi-api
     volumes:
       - grafana-volume:/var/lib/grafana
-    links:
-      - "gnocchi-api:gnocchi"
-
-  fake-phy-host:
-    image: collectd
-    build:
-      context: collectd
-      args:
-        package_name: "${COLLECTD_GNOCCHI_PACKAGE_NAME:-collectd-gnocchi}"
-    environment:
-      COLLECTD_INTERVAL: 10
-    depends_on:
-      - gnocchi-api
-    links:
-      - "gnocchi-api:gnocchi"
-
-  prom:
-    image: prometheus
-    build:
-      context: prometheus
-    depends_on:
-      - gnocchi-api
-    ports:
-      - "9090:9090"
     links:
       - "gnocchi-api:gnocchi"
 


### PR DESCRIPTION
This commit moves the fake host and Prometheus support into separate
Dockerfiles.   This permits someone to select which services come up
by composing multiple YAML document on the command line. For example,
the standard invocation will bring up only the core Gnocchi services:

    docker-compose up

To also add in the Prometheus service:

    docker-compose -f docker-compose.yaml -f docker-compose-prom.yaml up

Etc.