### PR TITLE
fix build of grafana docker-image

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,7 +1,11 @@
 FROM grafana/grafana
+USER root
+RUN apt-get -qy update \
+	&&	apt-get -qy install curl
+USER grafana
 COPY --chown=grafana ./install-plugin.sh /install-plugin.sh
 COPY --chown=grafana ./configure.sh /configure.sh
 COPY --chown=grafana ./run-and-configure.sh /run-and-configure.sh
-COPY --chown=grafana ./dashboard.json /dashboard.json
-COPY --chown=grafana ./datasource.json /datasource.json
+COPY --chown=grafana ./dashboard.json /tmp/dashboard.json
+COPY --chown=grafana ./datasource.json /tmp/datasource.json
 ENTRYPOINT ["/run-and-configure.sh"]

--- a/grafana/configure.sh
+++ b/grafana/configure.sh
@@ -24,7 +24,7 @@ curl -v -# \
 
 
 echo '{"dashboard":' > /tmp/dashboard.json.mod
-sed -e 's/\${DS_GNOCCHI}/Gnocchi/g' /dashboard.json >> /tmp/dashboard.json.mod
+sed -e 's/\${DS_GNOCCHI}/Gnocchi/g' /tmp/dashboard.json >> /tmp/dashboard.json.mod
 echo '}' >> /tmp/dashboard.json.mod
 curl -v -# \
     -H "Expect:" \


### PR DESCRIPTION
two bugfixes:

1. curl is missing in current grafana image, so install it.
2. "put dashboard.json in /tmp #29"-change forgot to fix some further paths